### PR TITLE
:bug: fix: correct input id and label for attribute

### DIFF
--- a/src/views/template/base/create.html
+++ b/src/views/template/base/create.html
@@ -13,13 +13,13 @@
         </div>
 
         <div class="form-group">
-          <input type="checkbox" class="form-checkbox-input" id="checkbox" v-model="isHtml">
-          <label class="form-check-label" for="checkbox">直接输入 html （如果没有特殊要求，请不要勾选）</label>
+          <input type="checkbox" class="form-checkbox-input" id="rawhtml" v-model="isHtml">
+          <label class="form-check-label" for="rawhtml">直接输入 html （如果没有特殊要求，请不要勾选）</label>
         </div>
 
         <div class="form-group">
-          <input type="checkbox" class="form-checkbox-input" id="checkbox" v-model="isOriginal">
-          <label class="form-check-label" for="checkbox">原创请勾选，以保护你的权益</label>
+          <input type="checkbox" class="form-checkbox-input" id="original" v-model="isOriginal">
+          <label class="form-check-label" for="original">原创请勾选，以保护你的权益</label>
         </div>
 
         <div class="form-group">


### PR DESCRIPTION
在编辑文章界面，编辑框上方的两个 `label`标签，点击之后都只会选中第一个 `input`，修复了一下。